### PR TITLE
Do NOT set `bufhidden=unload`

### DIFF
--- a/autoload/fern/internal/viewer.vim
+++ b/autoload/fern/internal/viewer.vim
@@ -46,7 +46,7 @@ function! s:init() abort
         \ FernReveal
         \ call fern#internal#command#reveal#command(<q-mods>, [<f-args>])
 
-  setlocal buftype=nofile bufhidden=unload
+  setlocal buftype=nofile
   setlocal noswapfile nobuflisted nomodifiable
   setlocal signcolumn=yes
   " The 'foldmethod=manual' is required to avoid the following issue


### PR DESCRIPTION
Let users decide whether to set `hidden` or not.

Close #510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling and promise management in viewer functionality.
	- Improved robustness in the initialization and opening processes.
  
- **Bug Fixes**
	- Fixed issues related to buffer visibility and unloading behavior.

These updates lead to a more reliable and user-friendly experience when interacting with the viewer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->