### PR TITLE
Automatically restore `winfixwidth` when leaving the buffer

### DIFF
--- a/autoload/fern/internal/drawer/auto_winfixwidth.vim
+++ b/autoload/fern/internal/drawer/auto_winfixwidth.vim
@@ -6,9 +6,14 @@ function! fern#internal#drawer#auto_winfixwidth#init() abort
   augroup fern_internal_drawer_auto_winfixwidth_init
     autocmd! * <buffer>
     autocmd BufEnter <buffer> call s:set_winfixwidth()
+    autocmd BufWinLeave <buffer> call s:restore_winfixwidth()
   augroup END
 endfunction
 
 function! s:set_winfixwidth() abort
   let &l:winfixwidth = winnr('$') isnot# 1
+endfunction
+
+function! s:restore_winfixwidth() abort
+  let &l:winfixwidth = 0
 endfunction


### PR DESCRIPTION
Close #512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced window width management when switching between buffers
- **Bug Fixes**
	- Improved handling of window width settings during buffer transitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->