### PR TITLE
feat(mappings): show leaf node in preview window

### DIFF
--- a/autoload/fern/scheme/file/mapping.vim
+++ b/autoload/fern/scheme/file/mapping.vim
@@ -1,18 +1,25 @@
 let s:Promise = vital#fern#import('Async.Promise')
 
 function! fern#scheme#file#mapping#init(disable_default_mappings) abort
-  nnoremap <buffer><silent> <Plug>(fern-action-new-path)  :<C-u>call <SID>call('new_path')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-new-file)  :<C-u>call <SID>call('new_file')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-new-dir)   :<C-u>call <SID>call('new_dir')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-new-path=) :<C-u>call <SID>call_without_guard('new_path')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-new-file=) :<C-u>call <SID>call_without_guard('new_file')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-new-dir=)  :<C-u>call <SID>call_without_guard('new_dir')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-copy)      :<C-u>call <SID>call('copy')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-move)      :<C-u>call <SID>call('move')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-trash)     :<C-u>call <SID>call('trash')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-trash=)    :<C-u>call <SID>call_without_guard('trash')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-remove)    :<C-u>call <SID>call('remove')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-remove=)   :<C-u>call <SID>call_without_guard('remove')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-path)       :<C-u>call <SID>call('new_path')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-file)       :<C-u>call <SID>call('new_file')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-dir)        :<C-u>call <SID>call('new_dir')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-path=)      :<C-u>call <SID>call_without_guard('new_path')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-file=)      :<C-u>call <SID>call_without_guard('new_file')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-new-dir=)       :<C-u>call <SID>call_without_guard('new_dir')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-copy)           :<C-u>call <SID>call('copy')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-move)           :<C-u>call <SID>call('move')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-trash)          :<C-u>call <SID>call('trash')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-trash=)         :<C-u>call <SID>call_without_guard('trash')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-remove)         :<C-u>call <SID>call('remove')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-remove=)        :<C-u>call <SID>call_without_guard('remove')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-preview:left)   :<C-u>call <SID>call('preview', 'vertical topleft')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-preview:right)  :<C-u>call <SID>call('preview', 'vertical botright')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-preview:top)    :<C-u>call <SID>call('preview', 'topleft')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-preview:bottom) :<C-u>call <SID>call('preview', 'botright')<CR>
+
+  " Alias map
+  nnoremap <buffer><silent> <Plug>(fern-action-preview) <Plug>(fern-action-preview:bottom)
 
   if !a:disable_default_mappings
     nmap <buffer><nowait> N <Plug>(fern-action-new-file)
@@ -203,6 +210,23 @@ function! s:map_remove(helper) abort
         \.then({ -> a:helper.async.reload_node(root.__key) })
         \.then({ -> a:helper.async.redraw() })
         \.then({ -> a:helper.sync.echo(printf('%d items are removed', len(ps))) })
+endfunction
+
+function! s:map_preview(helper, prefix) abort
+  let node = a:helper.sync.get_cursor_node()
+  if node is# v:null
+    return s:Promise.reject('cursor node is not visible')
+  endif
+  if node.status isnot# a:helper.STATUS_NONE
+    return s:Promise.resolve()
+  endif
+
+  try
+    execute printf("noautocmd %s pedit %s", a:prefix, fnameescape(node._path))
+    return s:Promise.resolve()
+  catch
+    return s:Promise.reject(v:exception)
+  endtry
 endfunction
 
 function! s:new_file(helper, name) abort

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -1037,6 +1037,7 @@ GLOBAL							*fern-mapping-global*
 	      \ <Plug>(fern-action-open:edit)
 	      \ <Plug>(fern-action-open:edit-or-tabedit)
 <
+
 *<Plug>(fern-action-open)*
 	An alias to "open:edit" action. Users can overwrite this mapping to
 	change the default behavior of "open" action like:
@@ -1045,6 +1046,7 @@ GLOBAL							*fern-mapping-global*
 	      \ <Plug>(fern-action-open)
 	      \ <Plug>(fern-action-open:select)
 <
+
 *<Plug>(fern-action-diff:select)*
 *<Plug>(fern-action-diff:select:vert)*
 	Open a first marked node through "window selector"
@@ -1252,7 +1254,7 @@ The following mappings/actions are only available on file:// scheme.
 	nmap <buffer>
 	      \ <Plug>(my-trash)
 	      \ <Plug>(fern-action-trash=)y<CR>
-
+<
 *<Plug>(fern-action-remove)*
 *<Plug>(fern-action-remove=)*
 	Open a prompt to ask if fern can DELETE the cursor node or marked
@@ -1265,7 +1267,7 @@ The following mappings/actions are only available on file:// scheme.
 	nmap <buffer>
 	      \ <Plug>(my-trash)
 	      \ <Plug>(fern-action-trash=)y<CR>
-
+<
 *<Plug>(fern-action-cd:root)*
 *<Plug>(fern-action-lcd:root)*
 *<Plug>(fern-action-tcd:root)*
@@ -1371,6 +1373,19 @@ The following mappings/actions are only available on file:// scheme.
 *<Plug>(fern-action-yank:path)*
 	Yank the node path. In FILE scheme, |<Plug>(fern-action-yank)| is
 	aliased to this mapping.
+
+*<Plug>(fern-action-preview:left)*
+*<Plug>(fern-action-preview:right)*
+*<Plug>(fern-action-preview:top)*
+*<Plug>(fern-action-preview:bottom)*
+*<Plug>(fern-action-preview)*
+	Show the cursor node in a |preview-window| in similar manners of global
+	"open" actions.
+	If you would like to jump to the preview window, you can register a
+	mapping like:
+>
+	nnoremap P <Plug>(fern-action-preview)<C-w>p
+<
 
 -----------------------------------------------------------------------------
 DICT							*fern-mapping-dict*


### PR DESCRIPTION
## Overview

This revision introduces new plugin mappings for showing the current
leaf node in a preview window, through the 'preview' and
'preview:jump' actions available for the 'file://' scheme.

Documentation has been updated accordingly.

This was originally implemented in my personal dotfiles but I figured these features might be useful for the wider community. 

## Screenshots

![image](https://github.com/user-attachments/assets/e579f100-8fc7-468a-8bb2-95e957e85912)
![image](https://github.com/user-attachments/assets/d4f75066-8be5-4833-8a3c-ce1b1360eb5e)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added preview functionality to the `fern` file management plugin.
	- Introduced new mappings for various preview positions (left, right, top, bottom).
	- Updated existing mapping for clarity on its alias to the `open:edit` action.
	- Enhanced file browsing experience with improved preview capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->