### PR TITLE
Fix docs fern-action-remove

### DIFF
--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -1265,8 +1265,8 @@ The following mappings/actions are only available on file:// scheme.
 >
 	" Immediately delete
 	nmap <buffer>
-	      \ <Plug>(my-trash)
-	      \ <Plug>(fern-action-trash=)y<CR>
+	      \ <Plug>(my-remove)
+	      \ <Plug>(fern-action-remove=)y<CR>
 <
 *<Plug>(fern-action-cd:root)*
 *<Plug>(fern-action-lcd:root)*

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -1258,7 +1258,7 @@ The following mappings/actions are only available on file:// scheme.
 *<Plug>(fern-action-remove)*
 *<Plug>(fern-action-remove=)*
 	Open a prompt to ask if fern can DELETE the cursor node or marked
-	nodes. BE CAREFUL with this action while it DELETE the file/direcoty
+	nodes. BE CAREFUL with this action while it DELETE the file/directoty
 	and users cannot restore (like "rm" in terminal.)
 	You can use a "=" variant to apply values to the prompt and/or submit
 	a value like:


### PR DESCRIPTION
- Replace `fern-action-trash` with `fern-action-remove` in example.
- Fix typo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated deletion command details to clarify that removal is permanent and irreversible.
	- Renamed command references for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->