### PR TITLE
Fix grammar using typos

### DIFF
--- a/autoload/fern/fri/from.vim
+++ b/autoload/fern/fri/from.vim
@@ -1,6 +1,6 @@
 function! fern#fri#from#filepath(path) abort
   if !fern#internal#filepath#is_absolute(a:path)
-    throw printf('The "path" must be an absolute path but "%s" has specfied', a:path)
+    throw printf('The "path" must be an absolute path but "%s" has specified', a:path)
   endif
   let path = fern#internal#filepath#to_slash(a:path)
   return fern#fri#from#path(path)
@@ -8,7 +8,7 @@ endfunction
 
 function! fern#fri#from#path(path) abort
   if a:path[:0] !=# '/'
-    throw printf('The "path" must start from "/" but "%s" has specfied', a:path)
+    throw printf('The "path" must start from "/" but "%s" has specified', a:path)
   endif
   let path = fern#internal#path#simplify(a:path)
   let path = fern#fri#encode(path)

--- a/autoload/fern/internal/buffer.vim
+++ b/autoload/fern/internal/buffer.vim
@@ -69,7 +69,7 @@ function! fern#internal#buffer#open(bufname, ...) abort
   if options.keepjumps && options.opener ==# 'edit'
     let options.mods .= ' keepjumps'
   endif
-  " Use user frindly path on a real path to fix #284
+  " Use user friendly path on a real path to fix #284
   let bufname = filereadable(a:bufname)
         \ ? fnamemodify(a:bufname, ':~:.')
         \ : a:bufname

--- a/autoload/fern/internal/node.vim
+++ b/autoload/fern/internal/node.vim
@@ -146,7 +146,7 @@ function! fern#internal#node#expand_tree(node, nodes, provider, comparator, toke
   if a:node.status is# s:STATUS_NONE
     return s:Promise.reject('cannot expand leaf node')
   elseif a:node.status is# s:STATUS_EXPANDED
-    " Collpase first to avoid duplication
+    " Collapse first to avoid duplication
     return fern#internal#node#collapse(a:node, a:nodes, a:provider, a:comparator, a:token)
       \.then({ ns -> fern#internal#node#expand_tree(a:node, ns, a:provider, a:comparator, a:token) })
   elseif has_key(a:node.concealed, '__promise_expand')

--- a/autoload/fern/logger.vim
+++ b/autoload/fern/logger.vim
@@ -83,7 +83,7 @@ function! s:format(level, args, sep) abort
   return map(split(m, '\n'), { -> printf("%-5S:%s%s", a:level, a:sep, v:val) })
 endfunction
 
-" For backword compatibility
+" For backward compatibility
 const g:fern#logger#DEBUG = g:fern#DEBUG
 const g:fern#logger#INFO = g:fern#INFO
 const g:fern#logger#WARN = g:fern#WARN

--- a/autoload/fern/scheme/dict/mapping.vim
+++ b/autoload/fern/scheme/dict/mapping.vim
@@ -144,7 +144,7 @@ function! s:map_remove(helper) abort
 
   let nodes = a:helper.sync.get_selected_nodes()
   let paths = map(copy(nodes), { _, v -> v._path })
-  let prompt = printf('The follwoing %d entries will be removed', len(paths))
+  let prompt = printf('The following %d entries will be removed', len(paths))
   for path in paths[:5]
     let prompt .= "\n" . path
   endfor

--- a/doc/fern-develop.txt
+++ b/doc/fern-develop.txt
@@ -185,7 +185,7 @@ like:
 	call add(g:fern#mapping#mappings, ['your_plugin'])
 >
 *g:fern#mapping#mappings*
-	A |List| of globally available mapping names. 
+	A |List| of globally available mapping names.
 	A target mapping MUST exist under "fern#mapping#" namespace.
 
 
@@ -199,7 +199,7 @@ Provider is a core instance to produce scheme plugin. The instance must has
 the following methods.
 
 				*fern-develop-scheme-provider.get_root()*
-.get_root({url})		
+.get_root({url})
 	Return a (partial) node instance of the {url} (|String|).
 	The node instance will be used as a root node of a tree.
 	It throws error when no node is found for the {url}.
@@ -239,8 +239,8 @@ the following methods.
 MAPPING					*fern-develop-scheme-mapping*
 
 Fern provides scheme mappings under "autoload/fern/scheme/{scheme}/mapping"
-directory.  Mapping MUST provide an init function as 
-"fern#scheme#{scheme}#mapping#{name}#init()" with a boolean argument to disable 
+directory.  Mapping MUST provide an init function as
+"fern#scheme#{scheme}#mapping#{name}#init()" with a boolean argument to disable
 default mappings.
 
 Mappings under that directory are registered automatically when a filename has
@@ -280,7 +280,7 @@ Following hook will be emitted by |fern#hook#emit()| from fern itself.
 
 "viewer:ready" ({helper})
 	Called when fern viewer has ready, mean that the buffer has opened and
-	all content has rendererd.
+	all content has rendered.
 	The {helper} is a helper instance described in |fern-develop-helper|.
 
 
@@ -312,7 +312,7 @@ VARIABLE				*fern-develop-helper-variable*
 	"include"	A |List| of |String| to include nodes
 	"exclude"	A |List| of |String| to exclude nodes
 
-	Develoeprs can refer each attributes but Do NOT modify.
+	Developers can refer each attributes but Do NOT modify.
 
 			*fern-develop-helper.bufnr*
 .bufnr

--- a/doc/fern.txt
+++ b/doc/fern.txt
@@ -287,7 +287,7 @@ Users can customize above appearance by the following variables.
 	A |String| used as a symbol of expanded branch node.
 	Default: "|- "
 
-See |FernHighlight| and |fern-highlight| to change pre-defeined |highlight|.
+See |FernHighlight| and |fern-highlight| to change pre-defined |highlight|.
 
 Or create user custom renderer to change the appearance completely.
 See |fern-develop-renderer| for more details.
@@ -387,7 +387,7 @@ VARIABLE						*fern-variable*
 	Note that even with this option, any |jump-motions| performed in a
 	fern buffer updates |jumplist|. For example, if user move cursors by
 	"G" in above situation, |CTRL-O| in last step jumps to the fern buffer
-	rather than a buffer "A" because a jump for "G" has recoreded in
+	rather than a buffer "A" because a jump for "G" has recorded in
 	|jumplist|.
 	Default: 0
 
@@ -405,7 +405,7 @@ VARIABLE						*fern-variable*
 
 *g:fern#disable_viewer_auto_duplication*
 	Set 1 to disable viewer auto duplication on |WinEnter| autocmd.
-	The duplication is mainly occured when user execute |split| or
+	The duplication is mainly occurred when user execute |split| or
 	|vsplit| command to duplicate window.
 
 *g:fern#disable_drawer_auto_winfixwidth*
@@ -589,7 +589,7 @@ COMMAND							*fern-command*
 	If {reveal} is specified, parent nodes of the node which is identified
 	by the {reveal} are expanded and the node will be focused.
 	The {reveal} must be a relative path separated by "/" from the
-	specfied {url}.
+	specified {url}.
 	Note that if the {url} is for "file" scheme, an absolute path can be
 	specified to the {reveal}.
 							*fern-opener*
@@ -608,7 +608,7 @@ COMMAND							*fern-command*
 	"edit/tabedit"	Open a buffer by |edit| or |tabedit| when the buffer
 			is |modified|
 
-	Additionally, any modifiers (|mods|) are allowd to be prepend (e.g.
+	Additionally, any modifiers (|mods|) are allowed to be prepend (e.g.
 	"topleft split".)
 
 	Note that the command can be followed by a '|' and another command.
@@ -933,7 +933,7 @@ GLOBAL							*fern-mapping-global*
 	root node.
 
 *<Plug>(fern-action-expand-tree:in)*
-	Recursively expand the tree on a cursor node and keep the cursor on the 
+	Recursively expand the tree on a cursor node and keep the cursor on the
 	root node (moves to the first child node after the cursor node)
 
 *<Plug>(fern-action-expand-tree)*
@@ -981,7 +981,7 @@ GLOBAL							*fern-mapping-global*
 	drawer style fern (|fern-glossary-anchor|.)
 
 *<Plug>(fern-action-open:drop)*
-	Open a cursor node or jump the window when it was already opend.
+	Open a cursor node or jump the window when it was already opened.
 	Note See |drop| for more details.
 
 *<Plug>(fern-action-open:edit-or-error)*
@@ -1258,7 +1258,7 @@ The following mappings/actions are only available on file:// scheme.
 *<Plug>(fern-action-remove)*
 *<Plug>(fern-action-remove=)*
 	Open a prompt to ask if fern can DELETE the cursor node or marked
-	nodes. BE CAREFUL with this action while it DELETE the file/directoty
+	nodes. BE CAREFUL with this action while it DELETE the file/directory
 	and users cannot restore (like "rm" in terminal.)
 	You can use a "=" variant to apply values to the prompt and/or submit
 	a value like:

--- a/test/fern/helper.vimspec
+++ b/test/fern/helper.vimspec
@@ -246,7 +246,7 @@ Describe fern#helper
         It does not reject the promise
           let [r, e] = Promise.wait(
                \ helper.async.sleep(1),
-               \ { 'timoeut': TIMEOUT },
+               \ { 'timeout': TIMEOUT },
                \)
           Assert Equals(e, v:null)
         End
@@ -261,7 +261,7 @@ Describe fern#helper
         It does not reject the promise
           let [r, e] = Promise.wait(
                \ helper.async.redraw(),
-               \ { 'timoeut': TIMEOUT },
+               \ { 'timeout': TIMEOUT },
                \)
           Assert Equals(e, v:null)
         End

--- a/test/fern/hook.vimspec
+++ b/test/fern/hook.vimspec
@@ -28,7 +28,7 @@ Describe fern#hook
   End
 
   Describe #remove()
-    It removes a specfied hook
+    It removes a specified hook
       let ns1 = []
       let ns2 = []
       call fern#hook#add('t', { -> extend(ns1, a:000) })


### PR DESCRIPTION
I noticed your latest commit and it had a type in it, so I fired up [typos](https://github.com/crate-ci/typos) and found some more.

Also, there is a typo on a function itself:

<img width="468" alt="Screenshot 2025-02-17 at 21 52 01" src="https://github.com/user-attachments/assets/7aa0fa0f-854e-4284-88ab-161337aa60ed" />

Is it safe to rename the function too?

I noticed however, typos does not seem to catch all.  E.g. _directoty_ it did not detect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected several grammatical errors in error messages and prompts to enhance clarity.
- **Documentation**
	- Updated text and formatting throughout user-facing documentation for improved readability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->