### PR TITLE
fix: Add missing closing parenthesis in keymap for mark:unset action

### DIFF
--- a/autoload/fern/mapping/mark.vim
+++ b/autoload/fern/mapping/mark.vim
@@ -3,7 +3,7 @@ let s:Promise = vital#fern#import('Async.Promise')
 function! fern#mapping#mark#init(disable_default_mappings) abort
   nnoremap <buffer><silent> <Plug>(fern-action-mark:clear)  :<C-u>call <SID>call('mark_clear')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-mark:set)    :<C-u>call <SID>call('mark_set')<CR>
-  nnoremap <buffer><silent> <Plug>(fern-action-mark:unset   :<C-u>call <SID>call('mark_unset')<CR>
+  nnoremap <buffer><silent> <Plug>(fern-action-mark:unset)  :<C-u>call <SID>call('mark_unset')<CR>
   nnoremap <buffer><silent> <Plug>(fern-action-mark:toggle) :<C-u>call <SID>call('mark_toggle')<CR>
   vnoremap <buffer><silent> <Plug>(fern-action-mark:set)    :call <SID>call('mark_set')<CR>
   vnoremap <buffer><silent> <Plug>(fern-action-mark:unset)  :call <SID>call('mark_unset')<CR>


### PR DESCRIPTION
Fixed a typo in the key mapping definition for the `mark:unset` action.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue with mark removal in the Vim environment to ensure the functionality works reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->