### PR TITLE
Use "\t" instead of " " for leading spaces in fern.vim

### DIFF
--- a/autoload/fern/renderer/default.vim
+++ b/autoload/fern/renderer/default.vim
@@ -92,7 +92,7 @@ function! s:render_node(node, base, options) abort
 endfunction
 
 call s:Config.config(expand('<sfile>:p'), {
-      \ 'leading': ' ',
+      \ 'leading': "\t",
       \ 'root_symbol': '',
       \ 'leaf_symbol': '|  ',
       \ 'collapsed_symbol': '|+ ',

--- a/ftplugin/fern.vim
+++ b/ftplugin/fern.vim
@@ -5,3 +5,4 @@ let b:did_ftplugin = 1
 
 setlocal cursorline
 setlocal nolist nowrap nospell
+setlocal tabstop=1

--- a/test/behavior/Fern.vimspec
+++ b/test/behavior/Fern.vimspec
@@ -37,9 +37,9 @@ Describe Fern
       Assert Equals(getline(1, '$'), [
             \ 'root',
             \ '|- deep/',
-            \ ' |- alpha/',
-            \ '  |- beta/',
-            \ '   |  gamma',
+            \ "\t|- alpha/",
+            \ "\t\t|- beta/",
+            \ "\t\t\t|  gamma",
             \ '|+ heavy/',
             \ '|+ shallow/',
             \ '|  leaf',
@@ -51,8 +51,8 @@ Describe Fern
       Assert Equals(getline(1, '$'), [
             \ 'root',
             \ '|- deep/',
-            \ ' |- alpha/',
-            \ '  |+ beta/',
+            \ "\t|- alpha/",
+            \ "\t\t|+ beta/",
             \ '|+ heavy/',
             \ '|+ shallow/',
             \ '|  leaf',
@@ -76,9 +76,9 @@ Describe Fern
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
             \ '|- deep/',
-            \ ' |- alpha/',
-            \ '  |- beta/',
-            \ '   |  gamma',
+            \ "\t|- alpha/",
+            \ "\t\t|- beta/",
+            \ "\t\t\t|  gamma",
             \ '|+ shallow/',
             \ '|  leaf',
             \])
@@ -93,9 +93,9 @@ Describe Fern
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
             \ '|- deep/',
-            \ ' |- alpha/',
-            \ '  |- beta/',
-            \ '   |  gamma',
+            \ "\t|- alpha/",
+            \ "\t\t|- beta/",
+            \ "\t\t\t|  gamma",
             \ '|+ shallow/',
             \ '|  leaf',
             \])
@@ -110,9 +110,9 @@ Describe Fern
       Assert Equals(winnr('$'), 1)
       Assert Equals(getline(2, '$'), [
             \ '|- deep/',
-            \ ' |- alpha/',
-            \ '  |- beta/',
-            \ '   |  gamma',
+            \ "\t|- alpha/",
+            \ "\t\t|- beta/",
+            \ "\t\t\t|  gamma",
             \ '|+ shallow/',
             \ '|  leaf',
             \])

--- a/test/fern/renderer/default.vimspec
+++ b/test/fern/renderer/default.vimspec
@@ -41,9 +41,9 @@ Describe fern#renderer#default
         Assert Equals(r, [
               \ 'root',
               \ '|- shallow/',
-              \ ' |+ alpha/',
-              \ ' |+ beta/',
-              \ ' |  gamma',
+              \ "\t|+ alpha/",
+              \ "\t|+ beta/",
+              \ "\t|  gamma",
               \])
       End
 
@@ -60,9 +60,9 @@ Describe fern#renderer#default
         Assert Equals(r, [
               \ 'root',
               \ '|- shallow/',
-              \ ' |+ alpha/',
-              \ ' |+ beta/',
-              \ ' |  gamma',
+              \ "\t|+ alpha/",
+              \ "\t|+ beta/",
+              \ "\t|  gamma",
               \])
       End
     End


### PR DESCRIPTION
Close #526

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced visual layout: Leading whitespace in hierarchical displays now uses a tab character, resulting in more precise spacing and improved clarity.
  - Refined text formatting: A new setting customizes tab stops to 1 space, delivering remarkably consistent indentation and improved alignment across content, significantly enhancing overall visual coherence and user experience.
  
- **Bug Fixes**
  - Improved test clarity: Adjusted whitespace in test assertions to align with updated formatting, ensuring consistency in visual representation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->